### PR TITLE
Feat: Allow configuration of App State Folder for paired clients

### DIFF
--- a/src/app/clients/actions/synchronization.ts
+++ b/src/app/clients/actions/synchronization.ts
@@ -181,6 +181,15 @@ export async function getPairedClientsWithSettingsAction(): Promise<{ success: b
         }
       }
 
+      // **KEY LOGIC**: If Wolf doesn't specify an app_state_folder, populate it with the unique wolf_client_id
+      // This makes the default behavior explicit and visible to the user
+      // - If Wolf returns undefined: Use client's unique ID as default
+      // - If Wolf returns empty string: Respect it (shared root)
+      // - If Wolf returns a custom value: Use that value
+      const appStateFolder = wolfClient?.app_state_folder !== undefined
+        ? wolfClient.app_state_folder
+        : client.wolfClientId; // Use unique ID as default
+
       return {
         id: client.id,
         wolf_client_id: client.wolfClientId,
@@ -196,7 +205,7 @@ export async function getPairedClientsWithSettingsAction(): Promise<{ success: b
         owner: 'Current User',
         // Include settings from Wolf API
         settings: settings,
-        app_state_folder: wolfClient?.app_state_folder || '',
+        app_state_folder: appStateFolder,
       };
     });
 

--- a/src/app/clients/actions/synchronization.ts
+++ b/src/app/clients/actions/synchronization.ts
@@ -195,7 +195,8 @@ export async function getPairedClientsWithSettingsAction(): Promise<{ success: b
         status: wolfClient?.status || 'paired',
         owner: 'Current User',
         // Include settings from Wolf API
-        settings: settings
+        settings: settings,
+        app_state_folder: wolfClient?.app_state_folder || '',
       };
     });
 

--- a/src/app/clients/components/EditClientSettingsDialog.tsx
+++ b/src/app/clients/components/EditClientSettingsDialog.tsx
@@ -46,6 +46,7 @@ type ClientWithOwner = {
   status?: string;
   wolf_client_id?: string;
   settings?: ClientSettings;
+  app_state_folder?: string;
 };
 
 interface EditClientSettingsDialogProps {
@@ -58,6 +59,7 @@ interface EditClientSettingsDialogProps {
 // Form validation schema
 const formSchema = z.object({
   friendly_name: z.string().min(1, "Client name is required").max(255, "Client name too long"),
+  app_state_folder: z.string().optional(),
   controllers_override: z.array(
     z.enum(["auto", "xbox", "nintendo", "ps"])
   ).default(["auto"]).transform((val) => val.length === 0 ? ["auto"] : val),
@@ -94,6 +96,7 @@ const EditClientSettingsDialog: React.FC<EditClientSettingsDialogProps> = ({
     resolver: zodResolver(formSchema),
     defaultValues: {
       friendly_name: "",
+      app_state_folder: "",
       controllers_override: ["auto"],
       mouse_acceleration: 1.0,
       h_scroll_acceleration: 1.0,
@@ -115,6 +118,7 @@ const EditClientSettingsDialog: React.FC<EditClientSettingsDialogProps> = ({
       // Use client settings if available, otherwise use defaults
       const defaultSettings = {
         friendly_name: client.friendly_name || "",
+        app_state_folder: client.app_state_folder || "",
         controllers_override: ["auto"] as Array<'auto' | 'xbox' | 'nintendo' | 'ps'>,
         mouse_acceleration: 1.0,
         h_scroll_acceleration: 1.0,
@@ -132,6 +136,7 @@ const EditClientSettingsDialog: React.FC<EditClientSettingsDialogProps> = ({
         
         settingsToLoad = {
           friendly_name: client.friendly_name || "",
+          app_state_folder: client.app_state_folder || "",
           controllers_override: normalizedControllers,
           mouse_acceleration: client.settings.mouse_acceleration || 1.0,
           h_scroll_acceleration: client.settings.h_scroll_acceleration || 1.0,
@@ -171,12 +176,13 @@ const EditClientSettingsDialog: React.FC<EditClientSettingsDialogProps> = ({
       try {
         await clientLogger.info(
           LogComponent.WOLF_UI,
-          "Attempting to update client settings and name",
+          "Attempting to update client settings, name, and app state folder",
           {
             clientId: client.wolf_client_id || client.id,
             databaseId: client.id,
             oldFriendlyName: client.friendly_name,
             newFriendlyName: data.friendly_name,
+            newAppStateFolder: data.app_state_folder,
             settings: data
           }
         );
@@ -193,7 +199,8 @@ const EditClientSettingsDialog: React.FC<EditClientSettingsDialogProps> = ({
         const result = await updateClientSettingsAndNameAction(
           client.wolf_client_id || client.id,
           data.friendly_name,
-          settings
+          settings,
+          data.app_state_folder
         );
 
         if (!result.success) {
@@ -276,6 +283,27 @@ const EditClientSettingsDialog: React.FC<EditClientSettingsDialogProps> = ({
                       />
                     </FormControl>
                     <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="app_state_folder"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>App State Folder</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="text"
+                        placeholder="Default (Unique per client)"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                    <p className="text-sm text-muted-foreground">
+                      Set a shared folder name to share game data across devices. Leave empty for default behavior.
+                    </p>
                   </FormItem>
                 )}
               />

--- a/src/app/clients/components/EditClientSettingsDialog.tsx
+++ b/src/app/clients/components/EditClientSettingsDialog.tsx
@@ -118,7 +118,7 @@ const EditClientSettingsDialog: React.FC<EditClientSettingsDialogProps> = ({
       // Use client settings if available, otherwise use defaults
       const defaultSettings = {
         friendly_name: client.friendly_name || "",
-        app_state_folder: client.app_state_folder || "",
+        app_state_folder: client.app_state_folder || client.wolf_client_id || "",
         controllers_override: ["auto"] as Array<'auto' | 'xbox' | 'nintendo' | 'ps'>,
         mouse_acceleration: 1.0,
         h_scroll_acceleration: 1.0,
@@ -136,7 +136,7 @@ const EditClientSettingsDialog: React.FC<EditClientSettingsDialogProps> = ({
         
         settingsToLoad = {
           friendly_name: client.friendly_name || "",
-          app_state_folder: client.app_state_folder || "",
+          app_state_folder: client.app_state_folder || client.wolf_client_id || "",
           controllers_override: normalizedControllers,
           mouse_acceleration: client.settings.mouse_acceleration || 1.0,
           h_scroll_acceleration: client.settings.h_scroll_acceleration || 1.0,
@@ -292,17 +292,28 @@ const EditClientSettingsDialog: React.FC<EditClientSettingsDialogProps> = ({
                 name="app_state_folder"
                 render={({ field }) => (
                   <FormItem>
-                    <FormLabel>App State Folder</FormLabel>
+                    <div className="flex justify-between items-center">
+                      <FormLabel>App State Folder</FormLabel>
+                      <Button
+                        type="button"
+                        variant="link"
+                        className="p-0 h-auto text-xs text-blue-400 hover:text-blue-300"
+                        onClick={() => field.onChange(client.wolf_client_id)}
+                      >
+                        Reset to Default (Unique ID)
+                      </Button>
+                    </div>
                     <FormControl>
                       <Input
                         type="text"
-                        placeholder="Default (Unique per client)"
+                        placeholder="Enter a shared folder name"
                         {...field}
+                        value={field.value ?? ""}
                       />
                     </FormControl>
                     <FormMessage />
                     <p className="text-sm text-muted-foreground">
-                      Set a shared folder name to share game data across devices. Leave empty for default behavior.
+                      To share data across devices, enter a common folder name. Leave empty to share at the root.
                     </p>
                   </FormItem>
                 )}

--- a/src/app/clients/components/PairedClientsCard.tsx
+++ b/src/app/clients/components/PairedClientsCard.tsx
@@ -177,8 +177,22 @@ const PairedClientsCard: React.FC<PairedClientsCardProps> = ({
                 <TableCell className="text-gray-400 py-3 px-4">
                   {client.owner || "N/A"}
                 </TableCell>
-                <TableCell className="text-gray-400 py-3 px-4">
-                  {client.app_state_folder || <span className="italic">Default (Unique)</span>}
+                <TableCell className="text-gray-400 py-3 px-4 font-mono text-xs">
+                  {(() => {
+                    if (client.app_state_folder === "") {
+                      return <span className="italic text-gray-500">Root</span>;
+                    }
+                    // If the value is the same as the client ID, it's the default
+                    if (client.app_state_folder === client.wolf_client_id) {
+                      return (
+                        <span className="italic text-gray-500 truncate" title={client.app_state_folder}>
+                          {client.app_state_folder}
+                        </span>
+                      );
+                    }
+                    // If it's a custom value
+                    return <span className="font-semibold text-gray-300">{client.app_state_folder}</span>;
+                  })()}
                 </TableCell>
                 <TableCell className="text-gray-400 py-3 px-4">
                   {formatLastSeen(client.last_seen, client.status)}

--- a/src/app/clients/components/PairedClientsCard.tsx
+++ b/src/app/clients/components/PairedClientsCard.tsx
@@ -32,6 +32,7 @@ type ClientWithOwner = ClientDevice & {
   friendly_name?: string;
   settings?: import("@/types/wolf").ClientSettings;
   session?: any;
+  app_state_folder?: string;
 };
 
 interface PairedClientsCardProps {
@@ -147,6 +148,9 @@ const PairedClientsCard: React.FC<PairedClientsCardProps> = ({
               </TableHead>
               <TableHead className="text-[#fffb96] py-3 px-4">Owner</TableHead>
               <TableHead className="text-[#fffb96] py-3 px-4">
+                App State Folder
+              </TableHead>
+              <TableHead className="text-[#fffb96] py-3 px-4">
                 Last Seen
               </TableHead>
               <TableHead className="text-[#fffb96] py-3 px-4">Status</TableHead>
@@ -172,6 +176,9 @@ const PairedClientsCard: React.FC<PairedClientsCardProps> = ({
                 </TableCell>
                 <TableCell className="text-gray-400 py-3 px-4">
                   {client.owner || "N/A"}
+                </TableCell>
+                <TableCell className="text-gray-400 py-3 px-4">
+                  {client.app_state_folder || <span className="italic">Default (Unique)</span>}
                 </TableCell>
                 <TableCell className="text-gray-400 py-3 px-4">
                   {formatLastSeen(client.last_seen, client.status)}
@@ -227,7 +234,7 @@ const PairedClientsCard: React.FC<PairedClientsCardProps> = ({
             {pairedClients.length === 0 && (
               <TableRow>
                 <TableCell
-                  colSpan={7}
+                  colSpan={8}
                   className="h-24 text-center text-gray-400 py-3 px-4"
                 >
                   No paired clients

--- a/src/app/clients/update-client-actions.ts
+++ b/src/app/clients/update-client-actions.ts
@@ -210,7 +210,8 @@ export async function updateClientSettingsAndNameAction(
         method: "POST",
         payload,
         wolfClientId,
-        originalSettings: settings
+        originalSettings: settings,
+        appStateFolder: appStateFolder
       }
     );
 

--- a/src/app/clients/update-client-actions.ts
+++ b/src/app/clients/update-client-actions.ts
@@ -40,7 +40,8 @@ async function getUsername(): Promise<string | null> {
 export async function updateClientSettingsAndNameAction(
   clientId: string,
   friendlyName: string,
-  settings: ClientSettings
+  settings: ClientSettings,
+  appStateFolder?: string
 ): Promise<ApiResponse<{}>> {
   const username = await getUsername();
   if (!username) {
@@ -187,10 +188,19 @@ export async function updateClientSettingsAndNameAction(
     const socketService = SocketService.getInstance();
     
     // Log the exact payload being sent to Wolf API
-    const payload = {
+    const payload: {
+      client_id: string | null;
+      app_state_folder?: string;
+      settings: Record<string, unknown>;
+    } = {
       client_id: wolfClientId,
       settings: wolfSettings as unknown as Record<string, unknown>
     };
+
+    // Only add app_state_folder to payload if it has been provided
+    if (appStateFolder !== undefined) {
+      payload.app_state_folder = appStateFolder;
+    }
     
     logger.debug(
       LogComponent.WOLF_UI,


### PR DESCRIPTION
This PR introduces the ability for users to specify a custom app_state_folder for each paired client through the "Edit Client Settings" dialog. This feature allows users to share application data (like game saves and configurations) across different devices by using a common folder, mirroring the functionality available in Wolf's config.toml.